### PR TITLE
Divided 'Spring Boot Application' into 3 relevant technologies

### DIFF
--- a/rules-themed/rules-windup/labels/core.windup.label.xml
+++ b/rules-themed/rules-windup/labels/core.windup.label.xml
@@ -62,7 +62,9 @@
                 <tag>WebSphere Web XML</tag>
                 <tag>WebSphere WS Binding</tag>
                 <tag>WebSphere WS Extension</tag>
-                <tag>Spring Boot Application</tag>
+                <tag>Spring Boot Configuration</tag>
+                <tag>Spring Boot Auto-configuration</tag>
+                <tag>Spring Boot Component Scan</tag>
             </unsuitable>
             <neutral>
                 <tag>Bouncy Castle</tag>
@@ -78,7 +80,7 @@
                 <tag>Swagger</tag>
                 <tag>Web XML*</tag>
                 <tag>WSDL</tag>
-                <tag>Spring War</tag>
+                <tag>Spring Deployable War</tag>
             </neutral>
         </label>
         <label id="tomcat">
@@ -90,7 +92,7 @@
                 <tag>JSF Page</tag>
                 <tag>JSP Page</tag>
                 <tag>Servlet</tag>
-                <tag>Spring War</tag>
+                <tag>Spring Deployable War</tag>
             </supported>
             <unsuitable>
                 <tag>CDI</tag>
@@ -137,7 +139,9 @@
                 <tag>WebSphere WS Binding</tag>
                 <tag>WebSphere WS Extension</tag>
                 <tag>WS Metadata</tag>
-                <tag>Spring Boot Application</tag>
+                <tag>Spring Boot Configuration</tag>
+                <tag>Spring Boot Auto-configuration</tag>
+                <tag>Spring Boot Component Scan</tag>
             </unsuitable>
             <neutral>
                 <tag>Java Source</tag>

--- a/rules-themed/rules-windup/labels/embedded.windup.label.xml
+++ b/rules-themed/rules-windup/labels/embedded.windup.label.xml
@@ -27,7 +27,9 @@
                 <tag>JAX-RS</tag> <!--based on Jarkata annotation {ee-flavor}.ws.rs.Path-->
                 <tag>JAX-WS</tag> <!--based on Jarkata annotation {ee-flavor}.jws.WebService-->
                 <tag>CDI</tag> <!--3rd party support-->
-                <tag>Spring Boot Application</tag> <!--annotation with org.springframework.boot.autoconfigure.SpringBootApplication-->
+                <tag>Spring Boot Configuration</tag> <!--annotation with org.springframework.boot.autoconfigure.SpringBootApplication-->
+                <tag>Spring Boot Auto-configuration</tag> <!--annotation with org.springframework.boot.autoconfigure.SpringBootApplication-->
+                <tag>Spring Boot Component Scan</tag> <!--annotation with org.springframework.boot.autoconfigure.SpringBootApplication-->
                 <tag>Spring</tag>  <!--spring*.jar-->
                 <tag>Spring Batch</tag> <!--spring-batch{*}.jar-->
                 <tag>Spring Boot</tag> <!--spring-boot{*}.jar-->
@@ -91,7 +93,7 @@
                 <tag>Maven XML</tag>
                 <tag>Properties</tag>
                 <tag>Web XML*</tag>
-                <tag>Spring War</tag>
+                <tag>Spring Deployable War</tag>
             </neutral>
         </label>
     </labels>

--- a/rules/rules-reviewed/README.md
+++ b/rules/rules-reviewed/README.md
@@ -71,55 +71,59 @@ Jakarta EE
 Embedded
 -----------
 
-| View              | Connect                 | Store                | Sustain                  | Execute               |
-|-------------------|-------------------------|----------------------|--------------------------|-----------------------|
-| AngularFaces      | 0MQ Client              | Apache HBase Client  | Acegi Security           | Apache Aries          |
-| Apache Tapestry   | ActiveMQ library        | Apache Ignite        | Apache Commons Validator | Apache Geronimo       |
-| CSS               | Amazon SQS Client       | Cache API            | Apache Flume             | Apache Hadoop         |
-| Eclipse RCP       | AMQP Client             | Cassandra Client     | Arquillian               | Apache Karaf          |
-| FreeMarker        | Axis                    | Coherence            | Atomikos JTA             | AspectJ               |
-| Grails            | Camel Messaging Client  | Derby Driver         | Bouncy Castle            | Camel                 |
-| GWT               | CXF                     | Dynacache            | Commons Logging          | Camunda               |
-| HTML              | HornetQ Client          | EclipseLink          | Cucumber                 | CDI                   |
-| ICEfaces          | HTTP Client             | ehcache              | DbUnit                   | Cloudera              |
-| JavaFX            | JBossMQ client          | H2 Driver            | EasyMock                 | Dagger                |
-| JavaScript        | Jersey                  | Hazelcast            | Geronimo JTA             | Drools                |
-| JFreeChart        | OpenWS                  | Hibernate            | GlassFish JTA            | Easy Rules            |
-| JMustache         | RabbitMQ Client         | Hibernate Cfg        | Guava Testing            | Elasticsearch         |
-| JSF               | Resource Adapter        | Hibernate Mapping    | Hamcrest                 | Eureka                |
-| JSTL              | RocketMQ Client         | Hibernate OGM        | HttpUnit                 | Feign                 |
-| Liferay           | Spring Messaging Client | HSQLDB Driver        | Java Transaction API     | Google Guice          |
-| LiferayFaces      | WebSphere EJB           | infinispan           | JBoss logging            | Istio                 |
-| MyFaces           | WSDL                    | JBoss Cache          | JBoss Transactions       | Javax Inject          |
-| OpenFaces         | XFire                   | JCache               | JSecurity                | JBPM                  |
-| Oracle ADF        |                         | Memcached            | JUnit                    | Jetty                 |
-| Play              |                         | Microsoft SQL Driver | KumuluzEE JTA            | Kibana                |
-| Portlet           |                         | MongoDB Client       | Log4J                    | Liferay               |
-| PrimeFaces        |                         | MySQL Driver         | Logback                  | Logstash              |
-| RichFaces         |                         | Oracle DB Driver     | Logging Utils            | MapR                  |
-| Seam              |                         | PostgreSQL Driver    | Mockito                  | Micrometer            |
-| Spring Boot Flo   |                         | Redis                | Narayana Arjuna          | Mule                  |
-| Spring MVC        |                         | Spring Boot Cache    | Nuxeo JTA/JCA            | Neo4j                 |
-| Spring Web        |                         | Spring Data          | OAUTH                    | Oracle Forms          |
-| Struts            |                         | Spring Data JPA      | OpenSAML                 | PicoContainer         |
-| Swing             |                         | SQLite Driver        | OW2 JTA                  | Quartz                |
-| SWT               |                         |                      | OWASP ESAPI              | ServiceMix            |
-| Thymeleaf         |                         |                      | PicketLink               | Spark                 |
-| Vaadin            |                         |                      | PowerMock                | Spring                |
-| Velocity          |                         |                      | Properties               | Spring Batch          |
-| WebLogic Web XML  |                         |                      | REST Assured             | Spring Boot           |
-| WebSphere Web XML |                         |                      | SAML                     | Spring Cloud Function |
-| Wicket            |                         |                      | Shiro                    | Spring DI             |
-|                   |                         |                      | SLF4J                    | Spring Integration    |
-|                   |                         |                      | Spring Boot Actuator     | Spring Scheduled      |
-|                   |                         |                      | Spring Cloud Config      | Spring Shell          |
-|                   |                         |                      | Spring JMX               | Swagger               |
-|                   |                         |                      | Spring Properties        | TensorFlow            |
-|                   |                         |                      | Spring Security          | Tomcat                |
-|                   |                         |                      | Spring Test              | Weld                  |
-|                   |                         |                      | Spring Transactions      | Zipkin                |
-|                   |                         |                      | SSL                      |                       |
-|                   |                         |                      | TestNG                   |                       |
-|                   |                         |                      | Unitils                  |                       |
-|                   |                         |                      | WSS4J                    |                       |
-|                   |                         |                      | XMLUnit                  |                       |
+| View              | Connect                 | Store                | Sustain                        | Execute               |
+|-------------------|-------------------------|----------------------|--------------------------------|-----------------------|
+| AngularFaces      | 0MQ Client              | Apache HBase Client  | Acegi Security                 | Apache Aries          |
+| Apache Tapestry   | ActiveMQ library        | Apache Ignite        | Apache Commons Validator       | Apache Geronimo       |
+| CSS               | Amazon SQS Client       | Cache API            | Apache Flume                   | Apache Hadoop         |
+| Eclipse RCP       | AMQP Client             | Cassandra Client     | Arquillian                     | Apache Karaf          |
+| FreeMarker        | Axis                    | Coherence            | Atomikos JTA                   | AspectJ               |
+| Grails            | Camel Messaging Client  | Derby Driver         | Bouncy Castle                  | Camel                 |
+| GWT               | CXF                     | Dynacache            | Commons Logging                | Camunda               |
+| HTML              | HornetQ Client          | EclipseLink          | Cucumber                       | CDI                   |
+| ICEfaces          | HTTP Client             | ehcache              | DbUnit                         | Cloudera              |
+| JavaFX            | JBossMQ client          | H2 Driver            | EasyMock                       | Dagger                |
+| JavaScript        | Jersey                  | Hazelcast            | Geronimo JTA                   | Drools                |
+| JFreeChart        | OpenWS                  | Hibernate            | GlassFish JTA                  | Easy Rules            |
+| JMustache         | RabbitMQ Client         | Hibernate Cfg        | Guava Testing                  | Elasticsearch         |
+| JSF               | Resource Adapter        | Hibernate Mapping    | Hamcrest                       | Eureka                |
+| JSTL              | RocketMQ Client         | Hibernate OGM        | HttpUnit                       | Feign                 |
+| Liferay           | Spring Messaging Client | HSQLDB Driver        | Java Transaction API           | Google Guice          |
+| LiferayFaces      | WebSphere EJB           | infinispan           | JBoss logging                  | Istio                 |
+| MyFaces           | WSDL                    | JBoss Cache          | JBoss Transactions             | Javax Inject          |
+| OpenFaces         | XFire                   | JCache               | JSecurity                      | JBPM                  |
+| Oracle ADF        |                         | Memcached            | JUnit                          | Jetty                 |
+| Play              |                         | Microsoft SQL Driver | KumuluzEE JTA                  | Kibana                |
+| Portlet           |                         | MongoDB Client       | Log4J                          | Liferay               |
+| PrimeFaces        |                         | MySQL Driver         | Logback                        | Logstash              |
+| RichFaces         |                         | Oracle DB Driver     | Logging Utils                  | MapR                  |
+| Seam              |                         | PostgreSQL Driver    | Mockito                        | Micrometer            |
+| Spring Boot Flo   |                         | Redis                | Narayana Arjuna                | Mule                  |
+| Spring MVC        |                         | Spring Boot Cache    | Nuxeo JTA/JCA                  | Neo4j                 |
+| Spring Web        |                         | Spring Data          | OAUTH                          | Oracle Forms          |
+| Struts            |                         | Spring Data JPA      | OpenSAML                       | PicoContainer         |
+| Swing             |                         | SQLite Driver        | OW2 JTA                        | Quartz                |
+| SWT               |                         |                      | OWASP ESAPI                    | ServiceMix            |
+| Thymeleaf         |                         |                      | PicketLink                     | Spark                 |
+| Vaadin            |                         |                      | PowerMock                      | Spring                |
+| Velocity          |                         |                      | Properties                     | Spring Batch          |
+| WebLogic Web XML  |                         |                      | REST Assured                   | Spring Boot           |
+| WebSphere Web XML |                         |                      | SAML                           | Spring Cloud Function |
+| Wicket            |                         |                      | Shiro                          | Spring Deployable War |
+|                   |                         |                      | SLF4J                          | Spring DI             |
+|                   |                         |                      | Spring Boot Actuator           | Spring Integration    |
+|                   |                         |                      | Spring Boot Auto-configuration | Spring Scheduled      |
+|                   |                         |                      | Spring Boot Component Scan     | Spring Shell          |
+|                   |                         |                      | Spring Boot Configuration      | Swagger               |
+|                   |                         |                      | Spring Cloud Config            | TensorFlow            |
+|                   |                         |                      | Spring Deployable War          | Tomcat                |
+|                   |                         |                      | Spring JMX                     | Weld                  |
+|                   |                         |                      | Spring Properties              | Weld                  |
+|                   |                         |                      | Spring Security                | Zipkin                |
+|                   |                         |                      | Spring Test                    |                       |
+|                   |                         |                      | Spring Transactions            |                       |
+|                   |                         |                      | SSL                            |                       |
+|                   |                         |                      | TestNG                         |                       |
+|                   |                         |                      | Unitils                        |                       |
+|                   |                         |                      | WSS4J                          |                       |
+|                   |                         |                      | XMLUnit                        |                       |

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
@@ -16,11 +16,11 @@
         <rule id="technology-usage-3rd-party-spring-03001-0">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Spring Boot configuration</property>
+                    <property name="name">Spring Boot Configuration</property>
                 </graph-query>
             </when>
             <perform>
-                <technology-identified name="Spring Boot configuration">
+                <technology-identified name="Spring Boot Configuration">
                     <tag name="Execute"/>
                     <tag name="Embedded"/>
                     <tag name="3rd party"/>
@@ -30,11 +30,11 @@
         <rule id="technology-usage-3rd-party-spring-03001-1">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Spring Boot auto-configuration</property>
+                    <property name="name">Spring Boot Auto-configuration</property>
                 </graph-query>
             </when>
             <perform>
-                <technology-identified name="Spring Boot auto-configuration">
+                <technology-identified name="Spring Boot Auto-configuration">
                     <tag name="Execute"/>
                     <tag name="Embedded"/>
                     <tag name="3rd party"/>
@@ -44,11 +44,11 @@
         <rule id="technology-usage-3rd-party-spring-03001-2">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Spring Boot component scan</property>
+                    <property name="name">Spring Boot Component Scan</property>
                 </graph-query>
             </when>
             <perform>
-                <technology-identified name="Spring Boot component scan">
+                <technology-identified name="Spring Boot Component Scan">
                     <tag name="Execute"/>
                     <tag name="Embedded"/>
                     <tag name="3rd party"/>

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
@@ -13,14 +13,42 @@
         <phase>PostMigrationRulesPhase</phase>
     </metadata>
     <rules>
-        <rule id="technology-usage-3rd-party-spring-03001">
+        <rule id="technology-usage-3rd-party-spring-03001-0">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Spring Boot Application</property>
+                    <property name="name">Spring Boot configuration</property>
                 </graph-query>
             </when>
             <perform>
-                <technology-identified name="Spring Boot Application">
+                <technology-identified name="Spring Boot configuration">
+                    <tag name="Execute"/>
+                    <tag name="Embedded"/>
+                    <tag name="3rd party"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-3rd-party-spring-03001-1">
+            <when>
+                <graph-query discriminator="TechnologyTagModel">
+                    <property name="name">Spring Boot auto-configuration</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Spring Boot auto-configuration">
+                    <tag name="Execute"/>
+                    <tag name="Embedded"/>
+                    <tag name="3rd party"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-3rd-party-spring-03001-2">
+            <when>
+                <graph-query discriminator="TechnologyTagModel">
+                    <property name="name">Spring Boot component scan</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Spring Boot component scan">
                     <tag name="Execute"/>
                     <tag name="Embedded"/>
                     <tag name="3rd party"/>
@@ -30,12 +58,13 @@
         <rule id="technology-usage-3rd-party-spring-03002">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Spring War</property>
+                    <property name="name">Spring Deployable War</property>
                 </graph-query>
             </when>
             <perform>
-                <technology-identified name="Spring War">
+                <technology-identified name="Spring Deployable War">
                     <tag name="Execute"/>
+                    <tag name="Embedded"/>
                     <tag name="3rd party"/>
                 </technology-identified>
             </perform>

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring-technology-usage.windup.xml
@@ -21,9 +21,9 @@
             </when>
             <perform>
                 <technology-identified name="Spring Boot Configuration">
-                    <tag name="Execute"/>
+                    <tag name="Sustain"/>
                     <tag name="Embedded"/>
-                    <tag name="3rd party"/>
+                    <tag name="Configuration Management"/>
                 </technology-identified>
             </perform>
         </rule>
@@ -35,9 +35,9 @@
             </when>
             <perform>
                 <technology-identified name="Spring Boot Auto-configuration">
-                    <tag name="Execute"/>
+                    <tag name="Sustain"/>
                     <tag name="Embedded"/>
-                    <tag name="3rd party"/>
+                    <tag name="Configuration Management"/>
                 </technology-identified>
             </perform>
         </rule>
@@ -49,9 +49,9 @@
             </when>
             <perform>
                 <technology-identified name="Spring Boot Component Scan">
-                    <tag name="Execute"/>
+                    <tag name="Sustain"/>
                     <tag name="Embedded"/>
-                    <tag name="3rd party"/>
+                    <tag name="Configuration Management"/>
                 </technology-identified>
             </perform>
         </rule>

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
@@ -14,11 +14,9 @@
     <rules>
         <rule id="3rd-party-spring-03001">
             <when>
-                <or>
-                    <javaclass references="org.springframework.boot.autoconfigure.SpringBootApplication">
-                        <location>ANNOTATION</location>
-                    </javaclass>
-                </or>
+                <javaclass references="org.springframework.boot.autoconfigure.SpringBootApplication">
+                    <location>ANNOTATION</location>
+                </javaclass>
             </when>
             <perform>
                 <technology-tag level="INFORMATIONAL">Spring Boot Configuration</technology-tag>

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
@@ -21,10 +21,9 @@
                 </or>
             </when>
             <perform>
-                <classification title="Embedded framework - Spring Boot Application" category-id="information" effort="0">
-                    <description>The application can start from a Spring Application.</description>
-                </classification>
-                <technology-tag level="INFORMATIONAL">Spring Boot Application</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot configuration</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot auto-configuration</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot component scan</technology-tag>
             </perform>
         </rule>
         <rule id="3rd-party-spring-03002">
@@ -37,10 +36,10 @@
                 </or>
             </when>
             <perform>
-                <classification title="Embedded framework - Spring War" category-id="information" effort="0">
+                <classification title="Embedded framework - Spring Deployable War" category-id="information" effort="0">
                     <description>The Spring application can start from War</description>
                 </classification>
-                <technology-tag level="INFORMATIONAL">Spring War</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Deployable War</technology-tag>
             </perform>
         </rule>
     </rules>

--- a/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
+++ b/rules/rules-reviewed/technology-usage/3rd-party-spring.windup.xml
@@ -21,9 +21,9 @@
                 </or>
             </when>
             <perform>
-                <technology-tag level="INFORMATIONAL">Spring Boot configuration</technology-tag>
-                <technology-tag level="INFORMATIONAL">Spring Boot auto-configuration</technology-tag>
-                <technology-tag level="INFORMATIONAL">Spring Boot component scan</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot Configuration</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot Auto-configuration</technology-tag>
+                <technology-tag level="INFORMATIONAL">Spring Boot Component Scan</technology-tag>
             </perform>
         </rule>
         <rule id="3rd-party-spring-03002">

--- a/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
@@ -14,7 +14,7 @@
          <rule id="technology-usage-3rd-party-spring-03001-0-test">
             <when>
                <not>
-                  <technology-statistics-exists name="Spring Boot configuration" number-found="1">
+                  <technology-statistics-exists name="Spring Boot Configuration" number-found="1">
                      <tag name="Execute"/>
                      <tag name="Embedded"/>
                      <tag name="3rd party"/>
@@ -28,7 +28,7 @@
          <rule id="technology-usage-3rd-party-spring-03001-1-test">
             <when>
                <not>
-                  <technology-statistics-exists name="Spring Boot auto-configuration" number-found="1">
+                  <technology-statistics-exists name="Spring Boot Auto-configuration" number-found="1">
                      <tag name="Execute"/>
                      <tag name="Embedded"/>
                      <tag name="3rd party"/>
@@ -42,7 +42,7 @@
          <rule id="technology-usage-3rd-party-spring-03001-2-test">
             <when>
                <not>
-                  <technology-statistics-exists name="Spring Boot component scan" number-found="1">
+                  <technology-statistics-exists name="Spring Boot Component Scan" number-found="1">
                      <tag name="Execute"/>
                      <tag name="Embedded"/>
                      <tag name="3rd party"/>

--- a/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
@@ -11,10 +11,10 @@
     <rulePath>../3rd-party-spring-technology-usage.windup.xml</rulePath>
    <ruleset>
       <rules>
-         <rule id="technology-usage-3rd-party-spring-03001-test">
+         <rule id="technology-usage-3rd-party-spring-03001-0-test">
             <when>
                <not>
-                  <technology-statistics-exists name="Spring Boot Application" number-found="1">
+                  <technology-statistics-exists name="Spring Boot configuration" number-found="1">
                      <tag name="Execute"/>
                      <tag name="Embedded"/>
                      <tag name="3rd party"/>
@@ -22,14 +22,43 @@
                </not>
             </when>
             <perform>
-               <fail message="Expected data not found for rule technology-usage-3rd-party-spring-03001"/>
+               <fail message="Expected data not found for rule technology-usage-3rd-party-spring-03001-0"/>
+            </perform>
+         </rule>
+         <rule id="technology-usage-3rd-party-spring-03001-1-test">
+            <when>
+               <not>
+                  <technology-statistics-exists name="Spring Boot auto-configuration" number-found="1">
+                     <tag name="Execute"/>
+                     <tag name="Embedded"/>
+                     <tag name="3rd party"/>
+                  </technology-statistics-exists>
+               </not>
+            </when>
+            <perform>
+               <fail message="Expected data not found for rule technology-usage-3rd-party-spring-03001-1"/>
+            </perform>
+         </rule>
+         <rule id="technology-usage-3rd-party-spring-03001-2-test">
+            <when>
+               <not>
+                  <technology-statistics-exists name="Spring Boot component scan" number-found="1">
+                     <tag name="Execute"/>
+                     <tag name="Embedded"/>
+                     <tag name="3rd party"/>
+                  </technology-statistics-exists>
+               </not>
+            </when>
+            <perform>
+               <fail message="Expected data not found for rule technology-usage-3rd-party-spring-03001-2"/>
             </perform>
          </rule>
           <rule id="technology-usage-3rd-party-spring-03002-test">
               <when>
                   <not>
-                      <technology-statistics-exists name="Spring War" number-found="1">
+                      <technology-statistics-exists name="Spring Deployable War" number-found="1">
                           <tag name="Execute"/>
+                          <tag name="Embedded"/>
                           <tag name="3rd party"/>
                       </technology-statistics-exists>
                   </not>

--- a/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/3rd-party-spring-technology-usage.windup.test.xml
@@ -15,9 +15,9 @@
             <when>
                <not>
                   <technology-statistics-exists name="Spring Boot Configuration" number-found="1">
-                     <tag name="Execute"/>
-                     <tag name="Embedded"/>
-                     <tag name="3rd party"/>
+                    <tag name="Sustain"/>
+                    <tag name="Embedded"/>
+                    <tag name="Configuration Management"/>
                   </technology-statistics-exists>
                </not>
             </when>
@@ -29,9 +29,9 @@
             <when>
                <not>
                   <technology-statistics-exists name="Spring Boot Auto-configuration" number-found="1">
-                     <tag name="Execute"/>
-                     <tag name="Embedded"/>
-                     <tag name="3rd party"/>
+                    <tag name="Sustain"/>
+                    <tag name="Embedded"/>
+                    <tag name="Configuration Management"/>
                   </technology-statistics-exists>
                </not>
             </when>
@@ -43,9 +43,9 @@
             <when>
                <not>
                   <technology-statistics-exists name="Spring Boot Component Scan" number-found="1">
-                     <tag name="Execute"/>
-                     <tag name="Embedded"/>
-                     <tag name="3rd party"/>
+                    <tag name="Sustain"/>
+                    <tag name="Embedded"/>
+                    <tag name="Configuration Management"/>
                   </technology-statistics-exists>
                </not>
             </when>

--- a/rules/rules-reviewed/technology-usage/tests/3rd-party-spring.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/3rd-party-spring.windup.test.xml
@@ -9,22 +9,41 @@
     <rulePath>../3rd-party-spring.windup.xml</rulePath>
    <ruleset>
       <rules>
-         <rule id="3rd-party-spring-03001-test">
+         <rule id="3rd-party-spring-03001-0-test">
             <when>
                <not>
-                   <classification-exists classification="Embedded framework - Spring Boot Application"/>
-                   <technology-tag-exists technology-tag="Spring Boot Application"/>
+                   <technology-tag-exists technology-tag="Spring Boot configuration"/>
                </not>
             </when>
             <perform>
-               <fail message="Expected data not found for rule 3rd-party-spring-03001"/>
+               <fail message="Expected data not found for rule 3rd-party-spring-03001-0"/>
+            </perform>
+         </rule>
+         <rule id="3rd-party-spring-03001-1-test">
+            <when>
+               <not>
+                   <technology-tag-exists technology-tag="Spring Boot "/>
+               </not>
+            </when>
+            <perform>
+               <fail message="Expected data not found for rule 3rd-party-spring-03001-1"/>
+            </perform>
+         </rule>
+         <rule id="3rd-party-spring-03001-2-test">
+            <when>
+               <not>
+                   <technology-tag-exists technology-tag="Spring Boot component scan"/>
+               </not>
+            </when>
+            <perform>
+               <fail message="Expected data not found for rule 3rd-party-spring-03001-2"/>
             </perform>
          </rule>
           <rule id="3rd-party-spring-03002-test">
               <when>
                   <not>
-                      <classification-exists classification="Embedded framework - Spring War"/>
-                      <technology-tag-exists technology-tag="Spring War"/>
+                      <classification-exists classification="Embedded framework - Spring Deployable War"/>
+                      <technology-tag-exists technology-tag="Spring Deployable War"/>
                   </not>
               </when>
               <perform>

--- a/rules/rules-reviewed/technology-usage/tests/3rd-party-spring.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/3rd-party-spring.windup.test.xml
@@ -12,7 +12,7 @@
          <rule id="3rd-party-spring-03001-0-test">
             <when>
                <not>
-                   <technology-tag-exists technology-tag="Spring Boot configuration"/>
+                   <technology-tag-exists technology-tag="Spring Boot Configuration"/>
                </not>
             </when>
             <perform>
@@ -32,7 +32,7 @@
          <rule id="3rd-party-spring-03001-2-test">
             <when>
                <not>
-                   <technology-tag-exists technology-tag="Spring Boot component scan"/>
+                   <technology-tag-exists technology-tag="Spring Boot Component Scan"/>
                </not>
             </when>
             <perform>


### PR DESCRIPTION
@showpune @PhilipCattanach

I've put some thoughts on rule ` 3rd-party-spring-03001`.

The `SpringBootApplication` annotation is a way to reduce the code because it basically enables 3 feature without having to declare each one of them ([Using the @SpringBootApplication Annotation](https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/using-boot-using-springbootapplication-annotation.html))

Attaching the classification `Embedded framework - Spring Boot Application` to the class where the annotation is found doesn't really fit for me because it's the JAR rather than a single specific class that embeds SB.
Hence I've removed it.

Regarding the tag, it might be more meaningful for experienced SB devs because it would let them understand that the optional `SpringBootApplication` annotation is used.
The idea that came to my mind was to divide that tag into the three corresponding technologies it enables by default, creating 3 tags:

- Spring Boot configuration
- Spring Boot auto-configuration
- Spring Boot component scan

Further changes:

- placed the above three technologies in `Sustain, Configuration Management, Embedded`
- added all the new technologies to the README
- Rule ` 3rd-party-spring-03002` was simply missing the 3rd placement tag, i.e. `<tag name="Embedded"/>`